### PR TITLE
14 tests fr getall routes implementieren

### DIFF
--- a/tests/routes/admins/admins.test.js
+++ b/tests/routes/admins/admins.test.js
@@ -1,1 +1,31 @@
 // tests/routes/admins/admins.test.js
+const request = require('supertest');
+const app = require('../../../index');
+
+describe('GET /api-ford-fiesta/admins/admins', () => {
+  test('sollte eine Liste von Admins mit Status 200 zurückgeben', async () => {
+    const { body: admins } = await request(app)
+      .get('/api-ford-fiesta/admins/admins')
+      .expect('Content-Type', /json/)
+      .expect(200);
+
+    expect(Array.isArray(admins)).toBe(true);
+  });
+});
+
+describe('GET /api-ford-fiesta/admins/users', () => {
+  test('sollte eine Liste von allen Users mit Status 200 zurückgeben', async () => {
+    const { body: admins } = await request(app)
+      .get('/api-ford-fiesta/admins/users')
+      .expect('Content-Type', /json/)
+      .expect(200);
+
+    expect(Array.isArray(admins)).toBe(true);
+  });
+});
+
+describe('GET /api-ford-fiesta/admin/all (Fehlerfälle)', () => {
+  test('sollte 404 für eine ungültige Route zurückgeben', async () => {
+    await request(app).get('/api-ford-fiesta/admin/invalidroute').expect(404);
+  });
+});

--- a/tests/routes/admins/admins.test.js
+++ b/tests/routes/admins/admins.test.js
@@ -1,0 +1,1 @@
+// tests/routes/admins/admins.test.js

--- a/tests/routes/comments/comments.test.js
+++ b/tests/routes/comments/comments.test.js
@@ -1,15 +1,22 @@
 // tests/routes/comments/comments.test.js
 const request = require('supertest');
-const app = require('../../../index'); // Importieren Sie die Express-Anwendung
+const app = require('../../../index');
 
 describe('GET /api-ford-fiesta/comments/all', () => {
-  test('sollte eine Liste von Kommentaren zurückgeben', async () => {
-    const response = await request(app)
+  test('sollte eine Liste von Kommentaren mit Status 200 zurückgeben', async () => {
+    const { body: comments } = await request(app)
       .get('/api-ford-fiesta/comments/all')
       .expect('Content-Type', /json/)
       .expect(200);
 
-    const myComments = response.body;
-    expect(Array.isArray(myComments)).toBe(true);
+    expect(Array.isArray(comments)).toBe(true);
+  });
+});
+
+describe('GET /api-ford-fiesta/comments/all (Fehlerfälle)', () => {
+  test('sollte 404 für eine ungültige Route zurückgeben', async () => {
+    await request(app)
+      .get('/api-ford-fiesta/comments/invalidroute')
+      .expect(404);
   });
 });

--- a/tests/routes/comments/comments.test.js
+++ b/tests/routes/comments/comments.test.js
@@ -1,3 +1,4 @@
+// tests/routes/comments/comments.test.js
 const request = require('supertest');
 const app = require('../../../index'); // Importieren Sie die Express-Anwendung
 

--- a/tests/routes/events/events.test.js
+++ b/tests/routes/events/events.test.js
@@ -1,0 +1,20 @@
+// tests/routes/events/events.test.js
+const request = require('supertest');
+const app = require('../../../index');
+
+describe('GET /api-ford-fiesta/events/all', () => {
+  test('sollte eine Liste von Events mit Status 200 zurückgeben', async () => {
+    const { body: events } = await request(app)
+      .get('/api-ford-fiesta/events/all')
+      .expect('Content-Type', /json/)
+      .expect(200);
+
+    expect(Array.isArray(events)).toBe(true);
+  });
+});
+
+describe('GET /api-ford-fiesta/events/all (Fehlerfälle)', () => {
+  test('sollte 404 für eine ungültige Route zurückgeben', async () => {
+    await request(app).get('/api-ford-fiesta/events/invalidroute').expect(404);
+  });
+});

--- a/tests/routes/ratings/ratings.test.js
+++ b/tests/routes/ratings/ratings.test.js
@@ -1,0 +1,20 @@
+// tests/routes/ratings/ratings.test.js
+const request = require('supertest');
+const app = require('../../../index');
+
+describe('GET /api-ford-fiesta/ratings/all', () => {
+  test('sollte eine Liste von Bewertungen mit Status 200 zurückgeben', async () => {
+    const { body: ratings } = await request(app)
+      .get('/api-ford-fiesta/ratings/all')
+      .expect('Content-Type', /json/)
+      .expect(200);
+
+    expect(Array.isArray(ratings)).toBe(true);
+  });
+});
+
+describe('GET /api-ford-fiesta/ratings/all (Fehlerfälle)', () => {
+  test('sollte 404 für eine ungültige Route zurückgeben', async () => {
+    await request(app).get('/api-ford-fiesta/ratings/invalidroute').expect(404);
+  });
+});

--- a/tests/routes/users/users.test.js
+++ b/tests/routes/users/users.test.js
@@ -1,0 +1,20 @@
+// tests/routes/users/users.test.js
+const request = require('supertest');
+const app = require('../../../index');
+
+describe('GET /api-ford-fiesta/users/all', () => {
+  test('sollte eine Liste von Benutzern mit Status 200 zurückgeben', async () => {
+    const { body: users } = await request(app)
+      .get('/api-ford-fiesta/users/all')
+      .expect('Content-Type', /json/)
+      .expect(200);
+
+    expect(Array.isArray(users)).toBe(true);
+  });
+});
+
+describe('GET /api-ford-fiesta/users/all (Fehlerfälle)', () => {
+  test('sollte 404 für eine ungültige Route zurückgeben', async () => {
+    await request(app).get('/api-ford-fiesta/users/invalidroute').expect(404);
+  });
+});

--- a/tests/routes/violations/violations.test.js
+++ b/tests/routes/violations/violations.test.js
@@ -1,0 +1,22 @@
+// tests/routes/violations/violations.test.js
+const request = require('supertest');
+const app = require('../../../index');
+
+describe('GET /api-ford-fiesta/violations/all', () => {
+  test('sollte eine Liste von Verstößen mit Status 200 zurückgeben', async () => {
+    const { body: violations } = await request(app)
+      .get('/api-ford-fiesta/violations/all')
+      .expect('Content-Type', /json/)
+      .expect(200);
+
+    expect(Array.isArray(violations)).toBe(true);
+  });
+});
+
+describe('GET /api-ford-fiesta/violations/all (Fehlerfälle)', () => {
+  test('sollte 404 für eine ungültige Route zurückgeben', async () => {
+    await request(app)
+      .get('/api-ford-fiesta/violations/invalidroute')
+      .expect(404);
+  });
+});


### PR DESCRIPTION
Unit-Tests für alle GET /all-Routen der API 